### PR TITLE
Unexpected exceptions do not return as a pass

### DIFF
--- a/test/simple_expectations/core_test.clj
+++ b/test/simple_expectations/core_test.clj
@@ -21,7 +21,7 @@
 
 (defrecord SimpleCheck []
     CustomPred
-    (expect-fn [e a] (:result a))
+    (expect-fn [e a] (true? (:result a)))
     (expected-message [e a str-e str-a] (format "%s of %s failures"
                                                                                               (:failing-size a)
                                                                                               (:num-tests a)))
@@ -30,3 +30,11 @@
 
 (expect (->SimpleCheck) (tc/quick-check 100 prop-no-42))
 
+
+;; Handling so unexpected exceptions do not return as passed
+
+(def prop-that-throws-exception
+  (prop/for-all [v gen/int]
+                (throw (ex-info "Exception" {}))))
+
+(expect (->SimpleCheck) (tc/quick-check 100 prop-that-throws-exception))


### PR DESCRIPTION
This is not ideal handling, because it doesn't display any exception info, but it does stop the test from saying that it's passed if an unexpected exception is thrown.